### PR TITLE
AUD-7380 add s3 prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bazels3cache",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export interface Config {
     socketTimeoutSeconds?: number;
     maxEntrySizeBytes?: number;
     allowGccDepfiles?: boolean;
-
+    s3Prefix?: string;
     asyncUpload?: {
         enabled?: boolean;
         maxPendingUploadMB?: number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -222,7 +222,7 @@ export function startServer(s3: AWS.S3, config: Config, onDoneInitializing: () =
                 } else {
                     const s3request = s3.getObject({
                          Bucket: config.bucket,
-                         Key: s3key
+                         Key: config.s3Prefix + s3key
                     }).promise();
 
                     s3request
@@ -300,7 +300,7 @@ export function startServer(s3: AWS.S3, config: Config, onDoneInitializing: () =
                             const streamedBody = fs.createReadStream(pth);
                             const s3request = s3.upload({
                                 Bucket: config.bucket,
-                                Key: s3key,
+                                Key: config.s3Prefix + s3key,
                                 Body: streamedBody,
                                 // Very important: The bucket owner needs full control of the uploaded
                                 // object, so that they can share the object with all the appropriate
@@ -351,7 +351,7 @@ export function startServer(s3: AWS.S3, config: Config, onDoneInitializing: () =
                 } else {
                     const s3request = s3.headObject({
                          Bucket: config.bucket,
-                         Key: s3key
+                         Key: config.s3Prefix + s3key
                     }).promise();
 
                     s3request
@@ -375,7 +375,7 @@ export function startServer(s3: AWS.S3, config: Config, onDoneInitializing: () =
 
                 const s3request = s3.deleteObject({
                     Bucket: config.bucket,
-                    Key: s3key
+                    Key: config.s3Prefix + s3key
                 }).promise();
 
                 s3request


### PR DESCRIPTION
https://auderenow.atlassian.net/browse/AUD-7380

Quick intro: bazel has built in support for a remote cache, but it can't work with S3 directly. bazels3cache is a node executable that proxies those remote cache requests so that you can use S3 as your bazel cache. It was deprecated late last year, and I wanted to make a couple other changes anyway, so I created this Audere-specific fork.

First up: pulling in a commit from another fork to support storing all the cache files with a specified prefix in your S3 bucket. I run with `--bucket=build-artifacts.auderenow.io --s3Prefix=mediapipe/bazel-cache/`.