### PR TITLE
AUD-7380 Handle expired credentials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,7 @@ function childMain(args: Args, onDoneInitializing: () => void) {
     initLogging(config); // Do this early, because when logging doesn't work, we're flying blind
     validateConfig(config); // throws if config is invalid
 
-    let credentials = fromIni();
-    let s3 = new S3({ credentials });
+    let s3 = new S3({});
     startServer(s3, config, onDoneInitializing);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ function fatalError(error: string) {
     process.exitCode = 1;
 }
 
-function daemonMain(args: Args, onDoneInitializing: () => void) {
+function childMain(args: Args, onDoneInitializing: () => void) {
     process.on("uncaughtException", function (err) {
         fatalError(""+err);
         process.exit(1); // hard stop; can't rely on just process.exitCode
@@ -36,58 +36,23 @@ function daemonMain(args: Args, onDoneInitializing: () => void) {
 }
 
 function main(args: string[]) {
-    const DONE_INITIALIZING = "done_initializing";
-
-    // When bazels3cache launches, it spawns a child bazels3cache with "--daemon"
+    // When bazels3cache launches, it spawns a child bazels3cache with "--child"
     // added to the command line.
     //
-    // The parent process then waits until that child process either exits, or sends
-    // us a "done_initializing" message. Then the parent process exits.
-    if (args.indexOf("--daemon") === -1) {
+    // The parent process then restarts the child process if it exits, allowing it
+    // to reload the AWS token from the file. This was the easiest method I could
+    // find to automatically reload the token file if it changes.
+    if (args.indexOf("--child") === -1) {
         // We are parent process
-        const devnull = fs.openSync("/dev/null", "r+");
-        // As described here https://github.com/nodejs/node/issues/17592, although
-        // child_process.fork() doesn't officially support `detached: true`, it works
-        const child = child_process.fork(__filename, ["--daemon"].concat(args),
-            <any>{ detached: true });
 
-        // This is so that if we terminate *without* receiving a "done_initializig"
-        // message from the child process, that's because the child process
-        // terminated unexpectedly, so we should exit with an error code.
-        //
-        // While we're waiting, the child process still has stdout and stderr, and
-        // can send any messages to there.
-        process.exitCode = 1;
+        const child = child_process.fork(__filename, ["--child"].concat(args),
+            { silent: true });
 
-        child.on("message", msg => {
-            if (msg === DONE_INITIALIZING) {
-                child.unref(); // don't wait for the child process to terminate
-                child.disconnect(); // don't wait on the ipc channel any more
-                process.exitCode = 0; // now we can exit cleanly
-            }
-        });
+        child.stdout.on("data", data => console.log(Buffer.from(data).toString("utf-8")));
+        child.on("exit", () => main(args));
     } else {
         // child process
-        daemonMain(minimist<Args>(args), () => {
-            // Now that the daemon has finished initializing, we need to:
-            // - close stdin, stdout, and stderr, so that we don't keep these handles
-            //   open cause problems
-            // - open /dev/null for all three of those
-            // - send a "done_initializing" message to our parent process.
-
-            fs.closeSync(0);
-            fs.closeSync(1);
-            fs.closeSync(2);
-            // Odd: If I don't do the following, then sometimes writes such as
-            // console.log() still show up on the screen. I don't get it.
-            process.stdout.write = process.stderr.write = (): undefined => undefined;
-            fs.openSync("/dev/null", "r+"); // stdin
-            fs.openSync("/dev/null", "r+"); // stdout
-            fs.openSync("/dev/null", "r+"); // stderr
-
-            // Tells the parent that we initialized successfully and it can exit
-            process.send(DONE_INITIALIZING);
-        });
+        childMain(minimist<Args>(args), () => {});
     }
 }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -26,7 +26,8 @@ export function initLogging(config: Config) {
             new (winston.transports.File)({
                 filename: config.logging.file,
                 json: false
-            })
+            }),
+            new (winston.transports.Console)(),
         ],
         padLevels: true,
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,8 @@ enum StatusCode {
     Forbidden = 403,
     NotFound = 404,
     MethodNotAllowed = 405,
-};
+    InternalServerError = 500,
+}
 
 function timeSinceMs(startTime: Date): number {
     const endTime = new Date();
@@ -92,11 +93,20 @@ function sendResponse(
     } else {
         winston.warn("Client closed connection before we could respond.")
     }
+
+    if (res.statusCode === StatusCode.InternalServerError) {
+        winston.error("Unrecoverable Error, shutting down");
+        process.exit();
+    }
 }
 
 function isIgnorableError(err: any) {
     // TODO add a comment explaining this
     return err.retryable === true;
+}
+
+function isExpiredTokenError(err: any) {
+    return err.Code === "ExpiredToken";
 }
 
 function shouldIgnoreError(err: any, config: Config) {
@@ -108,7 +118,9 @@ function getHttpResponseStatusCode(
     codeIfIgnoringError: StatusCode,
     config: Config
 ) {
-    if (shouldIgnoreError(err, config)) {
+    if (isExpiredTokenError(err)) {
+        return StatusCode.InternalServerError;
+    } else if (shouldIgnoreError(err, config)) {
         return codeIfIgnoringError;
     } else {
         return err.statusCode || StatusCode.NotFound;
@@ -143,7 +155,7 @@ export function startServer(s3: S3, config: Config, onDoneInitializing: () => vo
         debug(message);
         winston.error(message);
         winston.verbose(JSON.stringify(s3error, null, "  "));
-        if (++awsErrors >= config.errorsBeforePausing) {
+        if (!isExpiredTokenError(s3error) && ++awsErrors >= config.errorsBeforePausing) {
             winston.warn(`Encountered ${awsErrors} consecutive AWS errors; pausing AWS access for ${config.pauseMinutes} minutes`);
             awsPaused = true;
             awsPauseTimer = setTimeout(() => {


### PR DESCRIPTION
If you leave bazels3cache running and your aws token expires, the S3 requests obviously start failing. Unfortunately even getting a new token doesn't fix the issue, because the AWS JS SDK has no way to automatically reload the new token from a file. This is a bit of a hack, but I just restart the whole process in order to reload the AWS credentials whenever it hits an expired token. It will keep restarting every time an S3 request fails until you get a new token and they start succeeding.

I also return a 500 when this happens so that the error bubbles up to the bazel build output. The build will continue to run, but you'll see a fairly obvious warning that the remote cache is failing to help due to your expired token.